### PR TITLE
Add support for clearing and skipping cached widgets

### DIFF
--- a/src/vibe_widget/__init__.py
+++ b/src/vibe_widget/__init__.py
@@ -1,4 +1,4 @@
-from vibe_widget.core import VibeWidget, create, ComponentReference
+from vibe_widget.core import VibeWidget, create, clear, ComponentReference
 from vibe_widget.api import export, exports, imports, ExportHandle
 from vibe_widget.config import config, Config, models
 from vibe_widget.themes import Theme, theme, themes
@@ -7,6 +7,7 @@ __version__ = "0.1.0"
 __all__ = [
     "VibeWidget",
     "create",
+    "clear",
     "ComponentReference",
     "config",
     "Config",


### PR DESCRIPTION
This PR adds a new operator: vw.clear

vw.clear(widget5) # clears the widget5

vw.clear(target="widgets") # also includes "themes" | "audits" | "all"