### PR TITLE
python < 3.10 type compatability issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ src/vibe_widget/frontend/node_modules/.package-lock.json
 
 AGENTS.md
 logs.txt
+
+
+.claude/
+*.log

--- a/src/vibe_widget/config.py
+++ b/src/vibe_widget/config.py
@@ -4,7 +4,7 @@ Simplified configuration management for Vibe Widget.
 
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Literal
+from typing import Any, Dict, List, Optional, Literal, Union
 from pathlib import Path
 import json
 import time
@@ -22,8 +22,8 @@ MODELS_MANIFEST = _load_models_manifest()
 
 DEFAULT_MODEL = "google/gemini-3-flash-preview"
 
-_OPENROUTER_MODELS_CACHE: dict[str, Any] | None = None
-_OPENROUTER_MODELS_CACHE_TS: float | None = None
+_OPENROUTER_MODELS_CACHE: Optional[dict[str, Any]] = None
+_OPENROUTER_MODELS_CACHE_TS: Optional[float] = None
 
 
 class ModelsCatalog(dict):
@@ -55,7 +55,7 @@ def _fetch_openrouter_models(
     refresh: bool = True,
     cache_ttl_seconds: int = 3600,
     timeout_seconds: int = 10,
-) -> list[str] | None:
+) -> Optional[list[str]]:
     """Fetch the latest OpenRouter model IDs (best-effort)."""
     global _OPENROUTER_MODELS_CACHE, _OPENROUTER_MODELS_CACHE_TS
 
@@ -141,7 +141,7 @@ class Config:
     execution: str = "auto"  # "auto" or "approve"
     retry: int = 2  # Runtime repair attempts before blocking
     agent_preset: str = "project"
-    agent_run: dict[str, Any] | None = None
+    agent_run: Optional[dict[str, Any]] = None
     bypass_row_guard: bool = False
 
     def __repr__(self) -> str:  # pragma: no cover
@@ -290,8 +290,8 @@ def config(
     execution: str = None,
     retry: int = None,
     agent_preset: str = None,
-    agent_run: dict[str, Any] | None = None,
-    bypass_row_guard: bool | None = None,
+    agent_run: Optional[dict[str, Any]] = None,
+    bypass_row_guard: Optional[bool] = None,
     **kwargs
 ) -> Config:
     """

--- a/src/vibe_widget/core/widget.py
+++ b/src/vibe_widget/core/widget.py
@@ -2,6 +2,7 @@
 Core VibeWidget implementation.
 Clean, robust widget generation without legacy profile logic.
 """
+from __future__ import annotations
 from pathlib import Path
 from typing import Any, Union, TYPE_CHECKING
 from datetime import datetime, timezone

--- a/src/vibe_widget/llm/providers/base.py
+++ b/src/vibe_widget/llm/providers/base.py
@@ -1,7 +1,7 @@
 """Base class for LLM providers."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable
+from typing import Any, Callable, Optional, Union
 import re
 
 
@@ -17,7 +17,7 @@ class LLMProvider(ABC):
         self,
         description: str,
         data_info: dict[str, Any],
-        progress_callback: Callable[[str], None] | None = None,
+        progress_callback: Optional[Callable[[str], None]] = None,
     ) -> str:
         """Generate widget code from description and data info.
         
@@ -37,9 +37,9 @@ class LLMProvider(ABC):
         current_code: str,
         revision_description: str,
         data_info: dict[str, Any],
-        base_code: str | None = None,
-        base_components: list[str] | None = None,
-        progress_callback: Callable[[str], None] | None = None,
+        base_code: Optional[str] = None,
+        base_components: Optional[list[str]] = None,
+        progress_callback: Optional[Callable[[str], None]] = None,
     ) -> str:
         """Revise existing widget code based on a revision description.
         
@@ -82,7 +82,7 @@ class LLMProvider(ABC):
         description: str,
         data_info: dict[str, Any],
         level: str,
-        changed_lines: list[int] | None = None,
+        changed_lines: Optional[list[int]] = None,
     ) -> str:
         """Generate an audit report for widget code."""
         pass
@@ -91,7 +91,7 @@ class LLMProvider(ABC):
     def generate_text(
         self,
         prompt: str,
-        progress_callback: Callable[[str], None] | None = None,
+        progress_callback: Optional[Callable[[str], None]] = None,
     ) -> str:
         """Generate plain text from a prompt."""
         pass
@@ -100,8 +100,8 @@ class LLMProvider(ABC):
         self,
         description: str,
         data_info: dict[str, Any],
-        base_code: str | None = None,
-        base_components: list[str] | None = None,
+        base_code: Optional[str] = None,
+        base_components: Optional[list[str]] = None,
     ) -> str:
         """Build the prompt for code generation.
         
@@ -285,8 +285,8 @@ Begin the response with code immediately."""
         current_code: str,
         revision_description: str,
         data_info: dict[str, Any],
-        base_code: str | None = None,
-        base_components: list[str] | None = None,
+        base_code: Optional[str] = None,
+        base_components: Optional[list[str]] = None,
     ) -> str:
         """Build the prompt for code revision.
         
@@ -445,7 +445,7 @@ Return ONLY the corrected JavaScript code."""
         description: str,
         data_info: dict[str, Any],
         level: str,
-        changed_lines: list[int] | None = None,
+        changed_lines: Optional[list[int]] = None,
     ) -> str:
         """Build prompt for audit generation."""
         outputs = data_info.get("outputs", {})
@@ -581,7 +581,7 @@ CODE WITH LINE NUMBERS:
         outputs: dict,
         inputs: dict,
         actions: dict,
-        action_params: dict | None,
+        action_params: Optional[dict],
     ) -> str:
         """Build the outputs/inputs/actions section of the prompt."""
         if not outputs and not inputs and not actions:
@@ -704,11 +704,11 @@ Focus on modifying only what's necessary for the requested changes.
     @staticmethod
     def build_data_info(
         *,
-        outputs: dict[str, str] | None = None,
-        inputs: dict[str, str] | None = None,
-        actions: dict[str, str] | None = None,
-        action_params: dict[str, dict[str, str] | None] | None = None,
-        theme_description: str | None = None,
+        outputs: Optional[dict[str, str]] = None,
+        inputs: Optional[dict[str, str]] = None,
+        actions: Optional[dict[str, str]] = None,
+        action_params: Optional[dict[str, Optional[dict[str, str]]]] = None,
+        theme_description: Optional[str] = None,
     ) -> dict[str, Any]:
         """Build data info dictionary from summarized inputs."""
         outputs = outputs or {}

--- a/src/vibe_widget/llm/providers/openrouter_provider.py
+++ b/src/vibe_widget/llm/providers/openrouter_provider.py
@@ -1,7 +1,7 @@
 """OpenRouter provider implementation (OpenAI-compatible client)."""
 
 import os
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from openai import OpenAI
 
@@ -16,9 +16,9 @@ class OpenRouterProvider(LLMProvider):
     def __init__(
         self,
         model: str,
-        api_key: str | None = None,
-        site_url: str | None = None,
-        app_title: str | None = None,
+        api_key: Optional[str] = None,
+        site_url: Optional[str] = None,
+        app_title: Optional[str] = None,
     ):
         """
         Initialize OpenRouter provider.
@@ -53,7 +53,7 @@ class OpenRouterProvider(LLMProvider):
         self,
         description: str,
         data_info: dict[str, Any],
-        progress_callback: Callable[[str], None] | None = None,
+        progress_callback: Optional[Callable[[str], None]] = None,
     ) -> str:
         """Generate widget code using the configured OpenRouter model."""
         prompt = self._build_prompt(description, data_info)
@@ -82,9 +82,9 @@ class OpenRouterProvider(LLMProvider):
         current_code: str,
         revision_description: str,
         data_info: dict[str, Any],
-        base_code: str | None = None,
-        base_components: list[str] | None = None,
-        progress_callback: Callable[[str], None] | None = None,
+        base_code: Optional[str] = None,
+        base_components: Optional[list[str]] = None,
+        progress_callback: Optional[Callable[[str], None]] = None,
     ) -> str:
         """Revise existing widget code."""
         prompt = self._build_revision_prompt(
@@ -132,7 +132,7 @@ class OpenRouterProvider(LLMProvider):
         description: str,
         data_info: dict[str, Any],
         level: str,
-        changed_lines: list[int] | None = None,
+        changed_lines: Optional[list[int]] = None,
     ) -> str:
         """Generate an audit report for widget code."""
         prompt = self._build_audit_prompt(
@@ -153,7 +153,7 @@ class OpenRouterProvider(LLMProvider):
     def generate_text(
         self,
         prompt: str,
-        progress_callback: Callable[[str], None] | None = None,
+        progress_callback: Optional[Callable[[str], None]] = None,
     ) -> str:
         """Generate plain text from a prompt."""
         completion_params = {
@@ -186,7 +186,7 @@ class OpenRouterProvider(LLMProvider):
         self,
         description: str,
         data_info: dict[str, Any],
-        progress_callback: Callable[[str], None] | None = None,
+        progress_callback: Optional[Callable[[str], None]] = None,
     ) -> str:
         """Retry with a shorter prompt if context length exceeded."""
         reduced_info = data_info.copy()

--- a/src/vibe_widget/llm/tools/base.py
+++ b/src/vibe_widget/llm/tools/base.py
@@ -1,4 +1,5 @@
 """Base classes for agentic tool system."""
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Callable

--- a/src/vibe_widget/llm/tools/code_tools.py
+++ b/src/vibe_widget/llm/tools/code_tools.py
@@ -1,4 +1,5 @@
 """Code generation and validation tools."""
+from __future__ import annotations
 
 import re
 from typing import Any

--- a/src/vibe_widget/llm/tools/data_tools.py
+++ b/src/vibe_widget/llm/tools/data_tools.py
@@ -1,4 +1,5 @@
 """Data-related tools for loading and profiling data."""
+from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 from vibe_widget.llm.tools.base import Tool, ToolResult

--- a/src/vibe_widget/utils/code_parser.py
+++ b/src/vibe_widget/utils/code_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import time
 from typing import Dict, List, Tuple

--- a/src/vibe_widget/utils/widget_store.py
+++ b/src/vibe_widget/utils/widget_store.py
@@ -48,6 +48,7 @@ Design notes:
 - Anonymous widgets (no variable) extract name from description instead of "_anonymous_"
 - Edit operations use prompt delta to show what changed in the filename
 """
+from __future__ import annotations
 import hashlib
 import inspect
 import json
@@ -106,7 +107,7 @@ def extract_prompt_keywords(description: str, max_words: int = 3) -> list[str]:
     meaningful_words = []
     for word in words[:15]:  # Look at first 15 words
         # Keep visualization keywords and skip common words
-        if word in VIZ_KEYWORDS or (word not in SKIP_WORDS and len(word) > 2):
+                    "created_at": ISO timestamp,
             meaningful_words.append(word)
 
         # Stop after collecting enough words


### PR DESCRIPTION
fixing issue of using python < 3.10

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 import vibe_widget as vw
      3 vw.configure(api_key=")
      5 vw.create("create a scatterplot with sample data. When I click on a point create confetti") 

File ~/miniconda3/envs/vdlm/lib/python3.9/site-packages/vibe_widget/__init__.py:1
----> 1 from vibe_widget.core import VibeWidget, create, edit, load, clear, ComponentReference
      2 from vibe_widget.api import outputs, inputs, output, ExportHandle
      3 from vibe_widget.config import config, Config, models

File ~/miniconda3/envs/vdlm/lib/python3.9/site-packages/vibe_widget/core.py:23
     16 from vibe_widget.api import (
     17     ExportHandle,
     18     OutputBundle,
     19     InputsBundle,
     20     _build_inputs_bundle,
     21 )
     22 from vibe_widget.utils.code_parser import CodeStreamParser, RevisionStreamParser
---> 23 from vibe_widget.llm.agentic import AgenticOrchestrator
     24 from vibe_widget.llm.providers.base import LLMProvider
     25 from vibe_widget.config import (
     26     DEFAULT_MODEL,
     27     Config,
   (...)
     31     set_global_config,
     32 )

File ~/miniconda3/envs/vdlm/lib/python3.9/site-packages/vibe_widget/llm/__init__.py:1
----> 1 from vibe_widget.llm.providers.base import LLMProvider
      2 from vibe_widget.llm.providers.openrouter_provider import OpenRouterProvider
      3 from vibe_widget.llm.agentic import AgenticOrchestrator

File ~/miniconda3/envs/vdlm/lib/python3.9/site-packages/vibe_widget/llm/providers/__init__.py:1
----> 1 from vibe_widget.llm.providers.openrouter_provider import OpenRouterProvider
      3 __all__ = ["OpenRouterProvider"]

File ~/miniconda3/envs/vdlm/lib/python3.9/site-packages/vibe_widget/llm/providers/openrouter_provider.py:8
      4 from typing import Any, Callable
      6 from openai import OpenAI
----> 8 from vibe_widget.llm.providers.base import LLMProvider
     10 MAX_TOKENS = 20000
     12 class OpenRouterProvider(LLMProvider):

File ~/miniconda3/envs/vdlm/lib/python3.9/site-packages/vibe_widget/llm/providers/base.py:8
      4 from typing import Any, Callable
      5 import re
----> 8 class LLMProvider(ABC):
      9     """Abstract base class for LLM providers."""
     11     @abstractmethod
     12     def generate_widget_code(
     13         self,
   (...)
     16         progress_callback: Callable[[str], None] | None = None,
     17     ) -> str:

File ~/miniconda3/envs/vdlm/lib/python3.9/site-packages/vibe_widget/llm/providers/base.py:16, in LLMProvider()
      8 class LLMProvider(ABC):
      9     """Abstract base class for LLM providers."""
     11     @abstractmethod
     12     def generate_widget_code(
     13         self,
     14         description: str,
     15         data_info: dict[str, Any],
---> 16         progress_callback: Callable[[str], None] | None = None,
     17     ) -> str:
     18         """Generate widget code from description and data info.
     19         
     20         Args:
   (...)
     26             Generated widget code as a string
     27         """
     28         pass

TypeError: unsupported operand type(s) for |: '_CallableGenericAlias' and 'NoneType'